### PR TITLE
Fix link to previous OpenClaw articlew

### DIFF
--- a/_posts/daily/2026-02-02-openclaw-ollama.md
+++ b/_posts/daily/2026-02-02-openclaw-ollama.md
@@ -7,7 +7,7 @@ category: ["DAILY"]
 
 ## 도입
 
-[지난 글 (openclaw 설치 그리고 X(트위터) 권한 위임 후기)](/daily/openclaw/)에서는 OpenClaw 설치와 기본 세팅, 텔레그램 연동, 그리고 X(트위터) 권한 위임까지 다뤘다.  
+[지난 글 (openclaw 설치 그리고 X(트위터) 권한 위임 후기)](https://leejams.github.io/openclaw/)에서는 OpenClaw 설치와 기본 세팅, 텔레그램 연동, 그리고 X(트위터) 권한 위임까지 다뤘다.  
 그때는 Google Gemini를 기본 LLM으로 사용했는데, 클라우드 API를 쓰다 보니 사용량 제한이나 비용이 신경 쓰일 수 있다.
 
 그래서 이번에는 **Ollama**를 활용해서 완전히 로컬에서 돌아가는 AI 모델을 OpenClaw에 연동하는 방법을 정리해보려 한다.  


### PR DESCRIPTION
Updated the link to the previous article on OpenClaw installation and configuration, changing it from a relative to an absolute URL for better accessibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that only affects a single hyperlink in a blog post.
> 
> **Overview**
> Updates `_posts/daily/2026-02-02-openclaw-ollama.md` to change the “지난 글” link from a relative `/daily/openclaw/` path to the absolute `https://leejams.github.io/openclaw/` URL for more reliable navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af37a2e530d09825c0ea8279b5b7ca6d290dae9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->